### PR TITLE
 #rename-pgsql-uuid-field: update

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ class VersionXYZ extends IdToUuidMigration //or PostgresIdToUuidMigration
 }
 ```
 
+Alternatively you can specify second parameter to `migrate` method - custom temporary uuid field name
+
 3. After migration
 
 Check if your db structure is different from the doctrine schema. If it does then create another migration or merge with the previous one.

--- a/src/IdToUuidMigration.php
+++ b/src/IdToUuidMigration.php
@@ -37,16 +37,16 @@ class IdToUuidMigration extends AbstractMigration implements ContainerAwareInter
     {
     }
 
-    public function migrate(string $tableName, string $tmpUuidField = '__uuid__')
+    public function migrate(string $tableName, string $uuidColumnName = '__uuid__')
     {
         $this->write('Migrating ' . $tableName . '.id to UUIDs...');
         $this->prepare($tableName);
-        $this->addUuidFields($tmpUuidField);
-        $this->generateUuidsToReplaceIds($tmpUuidField);
+        $this->addUuidFields($uuidColumnName);
+        $this->generateUuidsToReplaceIds($uuidColumnName);
         $this->addThoseUuidsToTablesWithFK();
         $this->deletePreviousFKs();
         $this->renameNewFKsToPreviousNames();
-        $this->dropIdPrimaryKeyAndSetUuidToPrimaryKey($tmpUuidField);
+        $this->dropIdPrimaryKeyAndSetUuidToPrimaryKey($uuidColumnName);
         $this->restoreConstraintsAndIndexes();
         $this->write('Successfully migrated ' . $tableName . '.id to UUIDs!');
     }
@@ -102,15 +102,15 @@ class IdToUuidMigration extends AbstractMigration implements ContainerAwareInter
         $this->write('-> 0 foreign key detected.');
     }
 
-    private function addUuidFields(string $tmpUuidField)
+    private function addUuidFields(string $uuidColumnName)
     {
-        $this->connection->executeQuery('ALTER TABLE ' . $this->table . " ADD $tmpUuidField CHAR(36) COMMENT '(DC2Type:guid)' FIRST");
+        $this->connection->executeQuery('ALTER TABLE ' . $this->table . " ADD $uuidColumnName CHAR(36) COMMENT '(DC2Type:guid)' FIRST");
         foreach ($this->fks as $fk) {
             $this->connection->executeQuery('ALTER TABLE ' . $fk['table'] . ' ADD ' . $fk['tmpKey'] . ' CHAR(36) COMMENT \'(DC2Type:guid)\'');
         }
     }
 
-    private function generateUuidsToReplaceIds(string $tmpUuidField)
+    private function generateUuidsToReplaceIds(string $uuidColumnName)
     {
         $fetchs = $this->connection->fetchAll('SELECT id from ' . $this->table);
         if (count($fetchs) > 0) {
@@ -119,7 +119,7 @@ class IdToUuidMigration extends AbstractMigration implements ContainerAwareInter
                 $id = $fetch['id'];
                 $uuid = $this->generator->generate($this->em, null);
                 $this->idToUuidMap[$id] = $uuid;
-                $this->connection->update($this->table, [$tmpUuidField => $uuid], ['id' => $id]);
+                $this->connection->update($this->table, [$uuidColumnName => $uuid], ['id' => $id]);
             }
         }
     }
@@ -177,11 +177,11 @@ class IdToUuidMigration extends AbstractMigration implements ContainerAwareInter
         }
     }
 
-    private function dropIdPrimaryKeyAndSetUuidToPrimaryKey(string $tmpUuidField)
+    private function dropIdPrimaryKeyAndSetUuidToPrimaryKey(string $uuidColumnName)
     {
         $this->write('-> Creating the uuid primary key...');
         $this->connection->executeQuery('ALTER TABLE ' . $this->table . ' DROP PRIMARY KEY, DROP COLUMN id');
-        $this->connection->executeQuery('ALTER TABLE ' . $this->table . " CHANGE $tmpUuidField id CHAR(36) NOT NULL COMMENT '(DC2Type:guid)'");
+        $this->connection->executeQuery('ALTER TABLE ' . $this->table . " CHANGE $uuidColumnName id CHAR(36) NOT NULL COMMENT '(DC2Type:guid)'");
         $this->connection->executeQuery('ALTER TABLE ' . $this->table . ' ADD PRIMARY KEY (id)');
     }
 

--- a/src/PostgresIdToUuidMigration.php
+++ b/src/PostgresIdToUuidMigration.php
@@ -36,16 +36,16 @@ class PostgresIdToUuidMigration extends AbstractMigration
     {
     }
 
-    public function migrate(string $tableName): void
+    public function migrate(string $tableName, string $tmpUuidField = '__uuid__'): void
     {
         $this->write('Migrating ' . $tableName . '.id to UUIDs...');
         $this->prepare($tableName);
-        $this->addUuidFields();
-        $this->generateUuidsToReplaceIds();
+        $this->addUuidFields($tmpUuidField);
+        $this->generateUuidsToReplaceIds($tmpUuidField);
         $this->addThoseUuidsToTablesWithFK();
         $this->deletePreviousFKs();
         $this->renameNewFKsToPreviousNames();
-        $this->dropIdPrimaryKeyAndSetUuidToPrimaryKey();
+        $this->dropIdPrimaryKeyAndSetUuidToPrimaryKey($tmpUuidField);
         $this->restoreConstraintsAndIndexes();
         $this->write('Successfully migrated ' . $tableName . '.id to UUIDs!');
     }
@@ -111,10 +111,10 @@ class PostgresIdToUuidMigration extends AbstractMigration
         $this->write('-> 0 foreign key detected.');
     }
 
-    private function addUuidFields(): void
+    private function addUuidFields(string $tmpUuidField): void
     {
-        $this->connection->executeQuery("ALTER TABLE {$this->table} ADD __uuid__ UUID DEFAULT NULL");
-        $this->connection->executeQuery("COMMENT ON COLUMN {$this->table}.__uuid__ IS '(DC2Type:uuid)'");
+        $this->connection->executeQuery("ALTER TABLE {$this->table} ADD $tmpUuidField UUID DEFAULT NULL");
+        $this->connection->executeQuery("COMMENT ON COLUMN {$this->table}.$tmpUuidField IS '(DC2Type:uuid)'");
 
         foreach ($this->fks as $fk) {
             $fkTable = $fk['table'];
@@ -124,7 +124,7 @@ class PostgresIdToUuidMigration extends AbstractMigration
         }
     }
 
-    private function generateUuidsToReplaceIds(): void
+    private function generateUuidsToReplaceIds(string $tmpUuidField): void
     {
         if (!class_exists('Ramsey\Uuid\Uuid')) {
             throw new \Exception('Ramsey\Uuid is required');
@@ -136,7 +136,7 @@ class PostgresIdToUuidMigration extends AbstractMigration
                 $id = $fetch['id'];
                 $uuid = Uuid::uuid4()->toString();
                 $this->idToUuidMap[$id] = $uuid;
-                $this->connection->update($this->table, ['__uuid__' => $uuid], ['id' => $id]);
+                $this->connection->update($this->table, [$tmpUuidField => $uuid], ['id' => $id]);
             }
         }
     }
@@ -197,7 +197,7 @@ class PostgresIdToUuidMigration extends AbstractMigration
         }
     }
 
-    private function dropIdPrimaryKeyAndSetUuidToPrimaryKey(): void
+    private function dropIdPrimaryKeyAndSetUuidToPrimaryKey(string $tmpUuidField): void
     {
         $this->write('-> Creating the uuid primary key...');
 
@@ -209,7 +209,7 @@ class PostgresIdToUuidMigration extends AbstractMigration
         $this->connection->executeQuery("ALTER TABLE {$this->table} DROP COLUMN id");
         $this->connection->executeQuery('DROP SEQUENCE IF EXISTS ' . $this->pk['sequence']);
 
-        $this->connection->executeQuery("ALTER TABLE {$this->table} RENAME COLUMN __uuid__ TO id");
+        $this->connection->executeQuery("ALTER TABLE {$this->table} RENAME COLUMN $tmpUuidField TO id");
         $this->connection->executeQuery("ALTER TABLE {$this->table} ALTER COLUMN id SET NOT NULL");
         $this->connection->executeQuery("ALTER TABLE {$this->table} ADD CONSTRAINT {$pkName} PRIMARY KEY ({$pkIds})");
     }

--- a/src/PostgresIdToUuidMigration.php
+++ b/src/PostgresIdToUuidMigration.php
@@ -113,8 +113,8 @@ class PostgresIdToUuidMigration extends AbstractMigration
 
     private function addUuidFields(): void
     {
-        $this->connection->executeQuery("ALTER TABLE {$this->table} ADD uuid UUID DEFAULT NULL");
-        $this->connection->executeQuery("COMMENT ON COLUMN {$this->table}.uuid IS '(DC2Type:uuid)'");
+        $this->connection->executeQuery("ALTER TABLE {$this->table} ADD __uuid__ UUID DEFAULT NULL");
+        $this->connection->executeQuery("COMMENT ON COLUMN {$this->table}.__uuid__ IS '(DC2Type:uuid)'");
 
         foreach ($this->fks as $fk) {
             $fkTable = $fk['table'];
@@ -136,7 +136,7 @@ class PostgresIdToUuidMigration extends AbstractMigration
                 $id = $fetch['id'];
                 $uuid = Uuid::uuid4()->toString();
                 $this->idToUuidMap[$id] = $uuid;
-                $this->connection->update($this->table, ['uuid' => $uuid], ['id' => $id]);
+                $this->connection->update($this->table, ['__uuid__' => $uuid], ['id' => $id]);
             }
         }
     }
@@ -209,7 +209,7 @@ class PostgresIdToUuidMigration extends AbstractMigration
         $this->connection->executeQuery("ALTER TABLE {$this->table} DROP COLUMN id");
         $this->connection->executeQuery('DROP SEQUENCE IF EXISTS ' . $this->pk['sequence']);
 
-        $this->connection->executeQuery("ALTER TABLE {$this->table} RENAME COLUMN uuid TO id");
+        $this->connection->executeQuery("ALTER TABLE {$this->table} RENAME COLUMN __uuid__ TO id");
         $this->connection->executeQuery("ALTER TABLE {$this->table} ALTER COLUMN id SET NOT NULL");
         $this->connection->executeQuery("ALTER TABLE {$this->table} ADD CONSTRAINT {$pkName} PRIMARY KEY ({$pkIds})");
     }


### PR DESCRIPTION
Proposal of change.
Reason: had to switch to uuids on old app where uuid field has been already used for something else than primary key id.
If it is okeyed I can change the mysql as well